### PR TITLE
GH-27: Add the "Custom Search JSON API" along with "Custom Search Site Restricted JSON API"

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,20 +2,20 @@
 
 Replace WordPress default search with Google Custom Search results.
 
-**Contributors:** [rtCamp](https://github.com/rtCamp/), [Kiran Potphode](https://github.com/kiranpotphode/)
+**Contributors:** [rtCamp](https://github.com/rtCamp/), [Kiran Potphode](https://github.com/kiranpotphode/), [Shalin Shah](https://github.com/SH4LIN)
 
 **Tags:** google, search, cse, custom search engine, programmable search, programmable search engine, google cse, google custom search engine, google programmable search, google programmable search engine, google search
 
 **Requires at least:** 4.9
 
-**Tested up to:** 5.5
+**Tested up to:** 6.4.2
 
 **License:** [GPLv2 or later](http://www.gnu.org/licenses/gpl-2.0.html)
 
-**Requires PHP:** 8.0+
+**Requires PHP:** 7.4
 
 ## Description
-This plugin will replace the WordPress default search query with server-side results from [Custom Search Site Restricted JSON API](https://developers.google.com/custom-search/v1/site_restricted_api).
+This plugin will replace the WordPress default search query with server-side results from either the [Custom Search Site Restricted JSON API](https://developers.google.com/custom-search/v1/site_restricted_api) or the [Custom Search JSON API](https://developers.google.com/custom-search/v1/overview). You can make your selection within the settings > Reading > Search type. This replacement is done on the WordPress back-end, so results appear as normal within WordPress search.
 
 ## Requirements
 - [Google API Key](https://console.developers.google.com/apis/credentials)
@@ -24,11 +24,14 @@ This plugin will replace the WordPress default search query with server-side res
 ## Setup
 - [Get Google API key](https://developers.google.com/custom-search/v1/introduction). An API key is a way to identify your client to Google.
 - [Get Programmable Search engine ID](https://cse.google.com/). In settings, restrict the Search engine to only search for your one site.
- - On WordPress dashboard, set API Key and Custom Search Engine ID in the plugin settings. `Dashboard > Settings > Reading > Search with Google Settings`.
+- On WordPress dashboard, set API Key and Custom Search Engine ID in the plugin settings. `Dashboard > Settings > Reading > Search with Google Settings`.
+- Select the search type from Custom Search Site Restricted JSON API or Custom Search API. (Refer [#Notes](#notes) section for more details)
 
 ## Notes
 - Custom Search Site Restricted JSON API can show only 100 search results for the query.
 - A result page can have maximum of 10 results.
+- Assistance for Custom Site Restricted Search JSON API is scheduled to cease as of December 18, 2024. [Read more](https://developers.google.com/custom-search/v1/site_restricted_api). Due to this modification, we are introducing an opt-in feature that enables the use of solely the Custom Search API, as opposed to the Custom Site-restricted Search API. This will allow you to continue using the Custom Search API after December 18, 2024.
+- Custom Site Search API has a daily limit of 10,000 queries per day. [Read more](https://developers.google.com/custom-search/v1/overview#pricing).
 
 ## Contribute
 

--- a/assets/css/settings.css
+++ b/assets/css/settings.css
@@ -1,0 +1,54 @@
+.switch-wrapper {
+	display: flex;
+	align-items: center;
+	justify-content: flex-start;
+	gap: 14px;
+	flex-wrap: wrap;
+}
+
+.switch {
+	position: relative;
+	display: inline-block;
+	width: 50px;
+	height: 24px;
+}
+
+.switch input {
+	opacity: 0;
+	width: 0;
+	height: 0;
+	overflow: hidden;
+}
+
+.slider {
+	position: absolute;
+	cursor: pointer;
+	top: 0;
+	left: 0;
+	right: 0;
+	bottom: 0;
+	display: flex;
+	align-items: center;
+	background-color: #ccc;
+	-webkit-transition: transform .4s;
+	transition: transform .4s;
+	border-radius: 34px;
+}
+
+.slider::before {
+	position: absolute;
+	content: "";
+	height: 18px;
+	width: 18px;
+	left: 2px;
+	background-color: white;
+	-webkit-transition: .4s;
+	transition: .4s;
+	border-radius: 50%;
+}
+
+input[name="gcs_search_type"]:checked ~ .slider:before {
+	-webkit-transform: translateX(calc(50px - 20px - 2px));
+	-ms-transform: translateX(calc(50px - 20px - 2px));
+	transform: translateX(calc(50px - 20px - 2px));
+}

--- a/inc/classes/class-assets.php
+++ b/inc/classes/class-assets.php
@@ -1,0 +1,57 @@
+<?php
+/**
+ * Assets class.
+ *
+ * @package search-with-google
+ */
+
+namespace RT\Search_With_Google\Inc;
+
+use RT\Search_With_Google\Inc\Traits\Singleton;
+
+/**
+ * Class Assets
+ */
+class Assets {
+
+	use Singleton;
+
+	/**
+	 * Construct method.
+	 */
+	protected function __construct() {
+
+		$this->setup_hooks();
+
+	}
+
+	/**
+	 * Action / Filters to be declare here.
+	 *
+	 * @return void
+	 */
+	protected function setup_hooks() {
+
+		add_action( 'admin_enqueue_scripts', array( $this, 'enqueue_admin_assets' ) );
+
+	}
+
+	/**
+	 * Enqueue admin assets.
+	 *
+	 * @param string $hook_suffix Hook suffix.
+	 *
+	 * @return void
+	 */
+	public function enqueue_admin_assets( $hook_suffix ) {
+
+		if ( 'options-reading.php' === $hook_suffix ) {
+			wp_enqueue_style(
+				'search-with-google-settings-style',
+				SEARCH_WITH_GOOGLE_URL . '/assets/css/settings.css',
+				array(),
+				filemtime( SEARCH_WITH_GOOGLE_PATH . '/assets/css/settings.css' )
+			);
+		}
+	}
+}

--- a/inc/classes/class-notice.php
+++ b/inc/classes/class-notice.php
@@ -46,15 +46,29 @@ class Notice {
 	 */
 	public function display_notice() {
 
-		$read_more_url = 'https://developers.google.com/custom-search/v1/site_restricted_api';
+		$custom_site_restricted_search_read_more = 'https://developers.google.com/custom-search/v1/site_restricted_api';
+		$custom_search_read_more                 = 'https://developers.google.com/custom-search/v1/overview#pricing';
 		?>
 		<div class="notice notice-error">
 			<p>
 				<?php
-				esc_html_e( 'Notice : This plugin uses a Custom site-restricted Search API which has been deprecated by Google. Hence, limiting its use to only users with existing API keys. Any new API request to Google will return a 403 error, and it will return an empty posts array on the front-end.', 'search-with-google' );
+				esc_html_e( 'According to a notification from Google, assistance for custom site-restricted search is scheduled to cease as of December 18, 2024.', 'search-with-google' );
 				?>
-				<a href="<?php echo esc_url( $read_more_url ); ?>" target="_blank">
+				<a href="<?php echo esc_url( $custom_site_restricted_search_read_more ); ?>" target="_blank">
 					<?php esc_html_e( 'Read more', 'search-with-google' ); ?>
+				</a>
+			</p>
+			<p>
+				<?php esc_html_e( 'Due to this modification, we are introducing an opt-in feature that enables the use of solely the Custom Search API, as opposed to the Custom Site-restricted Search API. You have the option to opt in for this change by ', 'search-with-google' ); ?>
+				<a href="<?php echo esc_url( admin_url( 'options-reading.php#search-type' ) ); ?>">
+					<?php esc_html_e( 'Settings > Reading', 'search-with-google' ); ?>
+				</a>
+			</p>
+
+			<p>
+				<?php esc_html_e( 'Note: If you utilize the Custom Search API, there are limitations on the daily volume of search queries allowed. Kindly refer ', 'search-with-google' ); ?>
+				<a href="<?php echo esc_url( $custom_search_read_more ); ?>" target="_blank">
+					<?php esc_html_e( 'Documentation', 'search-with-google' ); ?>
 				</a>
 			</p>
 		</div>

--- a/inc/classes/class-plugin.php
+++ b/inc/classes/class-plugin.php
@@ -22,6 +22,7 @@ class Plugin {
 	protected function __construct() {
 
 		// Load plugin classes.
+		Assets::get_instance();
 		Settings::get_instance();
 		Search::get_instance();
 		Notice::get_instance();

--- a/inc/classes/class-search-engine.php
+++ b/inc/classes/class-search-engine.php
@@ -17,13 +17,6 @@ class Search_Engine {
 	use Singleton;
 
 	/**
-	 * Custom Search Site Restricted JSON API URL.
-	 *
-	 * @var string
-	 */
-	const GOOGLE_API_URL = 'https://customsearch.googleapis.com/customsearch/v1/siterestrict';
-
-	/**
 	 * API Key.
 	 *
 	 * @var string
@@ -80,7 +73,7 @@ class Search_Engine {
 				'q'   => rawurlencode( $search_query ),
 				'num' => $posts_per_page,
 			),
-			self::GOOGLE_API_URL
+			$this->get_api_url()
 		);
 
 		if ( $page > 1 ) {
@@ -164,6 +157,24 @@ class Search_Engine {
 	public function get_start_index( $page, $posts_per_page ) {
 
 		return ( $page * $posts_per_page ) - ( $posts_per_page - 1 );
+
+	}
+
+	/**
+	 * Get API URL.
+	 *
+	 * @return string
+	 */
+	private function get_api_url() {
+
+		$search_type = get_option( 'gcs_search_type' );
+		$api_url     = 'https://www.googleapis.com/customsearch/v1/siterestrict';
+
+		if ( ! empty( $search_type ) ) {
+			$api_url = 'https://www.googleapis.com/customsearch/v1';
+		}
+
+		return $api_url;
 
 	}
 }

--- a/inc/classes/class-search-engine.php
+++ b/inc/classes/class-search-engine.php
@@ -170,7 +170,7 @@ class Search_Engine {
 		$search_type = get_option( 'gcs_search_type' );
 		$api_url     = 'https://www.googleapis.com/customsearch/v1/siterestrict';
 
-		if ( ! empty( $search_type ) ) {
+		if ( '1' === $search_type ) {
 			$api_url = 'https://www.googleapis.com/customsearch/v1';
 		}
 

--- a/inc/classes/class-settings.php
+++ b/inc/classes/class-settings.php
@@ -50,6 +50,7 @@ class Settings {
 
 		register_setting( 'reading', 'gcs_api_key', $args );
 		register_setting( 'reading', 'gcs_cse_id', $args );
+		register_setting( 'reading', 'gcs_search_type', $args );
 
 		// Register a new section in the "reading" page.
 		add_settings_section(
@@ -71,6 +72,15 @@ class Settings {
 			'gcs_cse_id',
 			__( 'Engine ID', 'search-with-google' ),
 			array( $this, 'cse_id_field_cb' ),
+			'reading',
+			'cse_settings_section'
+		);
+
+		// Add a new toggle setting field for selecting between custom search API and custom site-restricted search API.
+		add_settings_field(
+			'gcs_search_type',
+			__( 'Search Type', 'search-with-google' ),
+			array( $this, 'cse_search_type_field_cb' ),
 			'reading',
 			'cse_settings_section'
 		);
@@ -110,6 +120,29 @@ class Settings {
 		// Output the field.
 		?>
 		<input type="text" name="gcs_cse_id" value="<?php echo ! empty( $setting ) ? esc_attr( $setting ) : ''; ?>">
+		<?php
+	}
+
+	/**
+	 * Search Type field markup.
+	 *
+	 * @return void
+	 */
+	public function cse_search_type_field_cb() {
+		// Get the value of the setting we've registered with register_setting().
+		$setting = get_option( 'gcs_search_type' );
+		// Add slider toggle switch.
+		?>
+		<div class="switch-wrapper">
+			<span><?php esc_html_e( 'Custom Site Restricted Search API', 'search-with-google' ); ?></span>
+
+			<label class="switch">
+				<input id="search-type" type="checkbox" name="gcs_search_type" value="1" <?php echo ! empty( $setting ) ? 'checked' : ''; ?>>
+				<span class="slider"></span>
+			</label>
+
+			<span><?php esc_html_e( 'Custom Search API', 'search-with-google' ); ?></span>
+		</div>
 		<?php
 	}
 }

--- a/inc/classes/class-settings.php
+++ b/inc/classes/class-settings.php
@@ -129,21 +129,24 @@ class Settings {
 	 * @return void
 	 */
 	public function cse_search_type_field_cb() {
+
 		// Get the value of the setting we've registered with register_setting().
 		$setting = get_option( 'gcs_search_type' );
+
 		// Add slider toggle switch.
 		?>
 		<div class="switch-wrapper">
 			<span><?php esc_html_e( 'Custom Site Restricted Search API', 'search-with-google' ); ?></span>
 
 			<label class="switch">
-				<input id="search-type" type="checkbox" name="gcs_search_type" value="1" <?php echo ! empty( $setting ) ? 'checked' : ''; ?>>
+				<input id="search-type" type="checkbox" name="gcs_search_type" value="1" <?php checked( $setting, '1' ); ?>>
 				<span class="slider"></span>
 			</label>
 
 			<span><?php esc_html_e( 'Custom Search API', 'search-with-google' ); ?></span>
 		</div>
 		<?php
+
 	}
 }
 

--- a/readme.txt
+++ b/readme.txt
@@ -1,11 +1,11 @@
 === Search with Google ===
-Contributors: rtCamp, kiranpotphode
+Contributors: rtCamp, kiranpotphode, sh4lin
 Donate link: https://rtcamp.com/
 Tags: google, search, cse, custom search engine, programmable search, programmable search engine, google cse, google custom search engine, google programmable search, google programmable search engine, google search
 Requires at least: 4.8
-Tested up to: 5.5
-Stable tag: 1.0
-Requires PHP: 8.0
+Tested up to: 6.4.2
+Stable tag: 1.1
+Requires PHP: 7.4
 License: GPLv2 or later
 License URI: https://www.gnu.org/licenses/gpl-2.0.html
 
@@ -13,20 +13,23 @@ Replace WordPress default search with server-side rendered Google Custom Search 
 
 == Description ==
 
-This plugin will replace the WordPress default search query with server-side results from [Custom Search Site Restricted JSON API](https://developers.google.com/custom-search/v1/site_restricted_api). This replacement is done on the WordPress back-end, so results appear as normal within WordPress search.
+This plugin will replace the WordPress default search query with server-side results from either the [Custom Search Site Restricted JSON API](https://developers.google.com/custom-search/v1/site_restricted_api) or the [Custom Search JSON API](https://developers.google.com/custom-search/v1/overview). You can make your selection within the settings > Reading > Search type. This replacement is done on the WordPress back-end, so results appear as normal within WordPress search.
 
 = Requirements =
 1. [Google API Key](https://console.developers.google.com/apis/credentials)
-1. [Programmable Search engine ID](https://cse.google.com/all)
+2. [Programmable Search engine ID](https://cse.google.com/all)
+
 
 = Setup =
 1. [Get Google API key](https://developers.google.com/custom-search/v1/introduction). An API key is a way to identify your client to Google.
-1. [Get Programmable Search engine ID](https://cse.google.com/). In Google settings, restrict the Search engine to only search for your one site.
-1. On WordPress dashboard, set API Key and Custom Search Engine ID in the plugin settings. `Dashboard > Settings > Reading > Search with Google Settings`.
+2. [Get Programmable Search engine ID](https://cse.google.com/). In Google settings, restrict the Search engine to only search for your one site.
+3. On WordPress dashboard, set API Key and Custom Search Engine ID in the plugin settings. `Dashboard > Settings > Reading > Search with Google Settings`.
+4. Select the search type from Custom Search Site Restricted JSON API or Custom Search API. (Refer [Notes](#notes) section for more details)
 
 = Notes =
 1. Custom Search Site Restricted JSON API can show only 100 search results for the query.
-1. A result page can have maximum of 10 results.
+2. A result page can have maximum of 10 results.
+3. Assistance for Custom Site Restricted Search JSON API is scheduled to cease as of December 18, 2024. [Read more](https://developers.google.com/custom-search/v1/site_restricted_api). Due to this modification, we are introducing an opt-in feature that enables the use of solely the Custom Search API, as opposed to the Custom Site-restricted Search API. This will allow you to continue using the Custom Search API after December 18, 2024.
 
 = BTW, We're Hiring! =
 
@@ -66,23 +69,25 @@ Once you're ready to send a pull request, please run through the following check
 
 == Changelog ==
 
+= 1.1 =
+* Updated PHP code to be compatible with PHP 8.2
+* Fixed WordPress coding standards issues
+* Used VIP compatible code for WordPress VIP compatibility
+* Added support for the Custom JSON API
+* Added Deprecation notice for the Custom site-restricted JSON API
+
 = 1.0 =
 * Initial release.
 
-= 1.1 =
-* Updated PHP code to be compatible with PHP 8.0+
-* Fixed WordPress coding standards issues
-* Used VIP compatible code for WordPress VIP compatibility
-* Added Deprecation notice for the Custom site-restricted JSON API
-
 
 == Upgrade Notice ==
+
+= 1.1 =
+* Updated PHP code to be compatible with PHP 8.2
+* Fixed WordPress coding standards issues
+* Used VIP compatible code for WordPress VIP compatibility
+* Added support for the Custom JSON API
+* Added Deprecation notice for the Custom site-restricted JSON API
  
 = 1.0 =
 Initial release.
-
-= 1.1 =
-* Updated PHP code to be compatible with PHP 8.0+
-* Fixed WordPress coding standards issues
-* Used VIP compatible code for WordPress VIP compatibility
-* Added Deprecation notice for the Custom site-restricted JSON API

--- a/search-with-google.php
+++ b/search-with-google.php
@@ -2,7 +2,7 @@
 /**
  * Plugin Name: Search with Google
  * Description: Replace WordPress default search with Google Custom Search results.
- * Version:     1.0
+ * Version:     1.1
  * Author:      rtCamp
  * Author URI:  https://rtCamp.com
  * License:     GPLv2 or later
@@ -18,6 +18,10 @@ if ( ! defined( 'ABSPATH' ) ) {
 
 if ( ! defined( 'SEARCH_WITH_GOOGLE_PATH' ) ) {
 	define( 'SEARCH_WITH_GOOGLE_PATH', __DIR__ );
+}
+
+if ( ! defined( 'SEARCH_WITH_GOOGLE_URL' ) ) {
+	define( 'SEARCH_WITH_GOOGLE_URL', plugins_url( '', __FILE__ ) );
 }
 
 require_once SEARCH_WITH_GOOGLE_PATH . '/inc/helpers/autoloader.php';


### PR DESCRIPTION
## Overview
- This PR will add support for the custom search JSON API. This is an optional support so by default plugin will run on "Custom Search Site Restricted JSON API" We have to manually change the search type from Settings > Reading > Search type.
- It will also add the proper notice on the WP dashboard.
- Search will work as it is only request URL endpoint will change.

## Screenshot(s)/Video(s)

https://github.com/rtCamp/search-with-google/assets/56588503/48a7d72d-702c-4062-aedf-21b26c789476
https://github.com/rtCamp/search-with-google/assets/56588503/08950777-b6dc-45e0-ac8a-b862ec5298ce

## Fixes/Covers

- #27 
